### PR TITLE
Preferred link for PBS podcast episodes in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Podcasts and presentations
 ------------------------------------------------------------------------
 
 * [ThePrimeTime - The BEST CLI Tool](https://www.youtube.com/watch?v=n8sOmEe2SDg)
-* [Programming By Stealth episodes about jq](https://www.podfeet.com/blog/tag/jq/)
+* [Programming By Stealth](https://pbs.bartificer.net/) ([instalments](https://pbs.bartificer.net/#instalments) PBS 155 to PBS 167)
 
 Contribute
 ------------------------------------------------------------------------


### PR DESCRIPTION
One of the creators of the PBS podcast [requested](https://podfeet.slack.com/archives/CDJ5WRU2C/p1719238365661429?thread_ts=1719208932.952109&cid=CDJ5WRU2C) we change the hyperlink. This is that change. Thanks.